### PR TITLE
feat: restore vault from git repository

### DIFF
--- a/src/lib/git.rs
+++ b/src/lib/git.rs
@@ -62,7 +62,7 @@ impl<'a> Git<'a> {
                 "-C",
                 &self.target,
                 "commit",
-                "-m",
+                "--message",
                 &format!("backup @ {}", time),
             ])
             .spawn()?
@@ -86,6 +86,20 @@ impl<'a> Git<'a> {
                 &self.branch,
                 if force { "--force" } else { "--no-force" },
             ])
+            .spawn()?
+            .wait()?;
+
+        if !status.success() {
+            return Err(KyError::Git);
+        }
+
+        Ok(self)
+    }
+
+    pub fn clone(self) -> Result<Self, KyError> {
+        let status = self
+            .git()
+            .args(&["clone", &self.repo, &self.target, "--branch", &self.branch])
             .spawn()?
             .wait()?;
 

--- a/src/subcommand/git.rs
+++ b/src/subcommand/git.rs
@@ -28,6 +28,7 @@ pub enum GitCmd {
     Push(GitPush),
 
     /// Restore vault from a git repository
+    #[clap(visible_alias = "clone")]
     Restore(GitRestore),
 }
 


### PR DESCRIPTION
Now, the vault can be restored from a git repository by running `ky git restore`, which is, suppose to be, backed-up git `ky git push` or manually pushed via git CLI.

NOTE: `KY_GIT_REPO` and `KY_GIT_BRANCH` will be used to gather the details about the git repository.