### PR TITLE
change: connect to a named database instead of default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Rename `git push` to `git backup` [#6](https://github.com/numToStr/ky/pull/6)
 -   New encryption and hashing strategy [#8](https://github.com/numToStr/ky/pull/8)
+-   Connect to a named database instead of default [#9](https://github.com/numToStr/ky/pull/9)
 
 ## [0.0.1] - 2020-06-15
 


### PR DESCRIPTION
lmdb by default connects to the default database if the name is not given. So, Instead of connecting to default, now we are connecting to a named database which is `password`. This will also enable us to create multiple databases which can use for like, notes, 2fa codes, etc.