### PR TITLE
fix: don't print encrypted entry key on error

### DIFF
--- a/src/lib/database.rs
+++ b/src/lib/database.rs
@@ -51,33 +51,24 @@ impl KyDb {
 
     /// Insert a key-val pair into the databse
     pub fn set(&self, wtxn: &mut RwTxn, key: &str, val: &str) -> Result<(), KyError> {
-        let res = self
-            .db
-            .put(wtxn, key, val)
-            .map_err(|_| KyError::Set(key.to_string()))?;
+        let res = self.db.put(wtxn, key, val).map_err(|_| KyError::Set)?;
 
         Ok(res)
     }
 
     /// Retrieve a key-val pair from the databse
     pub fn get(&self, rtxn: &RoTxn, key: &str) -> Result<String, KyError> {
-        let bytes = self
-            .db
-            .get(&rtxn, key)
-            .map_err(|_| KyError::Get(key.to_string()))?;
+        let bytes = self.db.get(&rtxn, key).map_err(|_| KyError::Get)?;
 
         match bytes {
             Some(x) => Ok(x.to_string()),
-            _ => Err(KyError::NotFound(key.to_string())),
+            _ => Err(KyError::NotFound),
         }
     }
 
     /// Delete a key-val pair from the databse
     pub fn delete(&self, wtxn: &mut RwTxn, key: &str) -> Result<bool, KyError> {
-        let is_deleted = self
-            .db
-            .delete(wtxn, key)
-            .map_err(|_| KyError::Delete(key.to_string()))?;
+        let is_deleted = self.db.delete(wtxn, key).map_err(|_| KyError::Delete)?;
 
         Ok(is_deleted)
     }

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -21,20 +21,20 @@ pub enum KyError {
     #[error("Vault backup not found on the provided path!")]
     BackupDontExist,
 
-    #[error("Entry not found in the vault: `{0}`")]
-    NotFound(String),
+    #[error("Entry not found in the vault!")]
+    NotFound,
 
-    #[error("Entry already exist in the vault: `{0}`")]
-    Exist(String),
+    #[error("Entry already exist in the vault!")]
+    Exist,
 
-    #[error("Unable to get the entry: `{0}`")]
-    Get(String),
+    #[error("Unable to get the entry!")]
+    Get,
 
-    #[error("Unable to set the entry: `{0}`")]
-    Set(String),
+    #[error("Unable to set the entry!")]
+    Set,
 
-    #[error("Unable to delete the entry: `{0}`")]
-    Delete(String),
+    #[error("Unable to delete the entry~")]
+    Delete,
     // #endregion
     #[error("Unable to hash the password!")]
     PwdHash,

--- a/src/subcommand/add.rs
+++ b/src/subcommand/add.rs
@@ -42,7 +42,7 @@ impl Command for Add {
         let key = Cipher::for_key(&master_pwd).encrypt(&self.key.as_ref())?;
 
         if pwd_db.get(&rtxn, &key).is_ok() {
-            return Err(KyError::Exist(self.key.as_ref().to_string()));
+            return Err(KyError::Exist);
         }
 
         rtxn.commit()?;

--- a/src/subcommand/move.rs
+++ b/src/subcommand/move.rs
@@ -48,7 +48,7 @@ impl Command for Move {
         // now check if the new key exists or not
         let new_key = key_cipher.encrypt(&self.new_key.as_ref())?;
         if pwd_db.get(&rtxn, &new_key).is_ok() {
-            return Err(KyError::Exist(self.new_key.as_ref().to_string()));
+            return Err(KyError::Exist);
         }
 
         rtxn.commit()?;

--- a/src/subcommand/remove.rs
+++ b/src/subcommand/remove.rs
@@ -37,9 +37,7 @@ impl Command for Remove {
 
         let key = Cipher::for_key(&master_pwd).encrypt(&self.key.as_ref())?;
 
-        if pwd_db.get(&rtxn, &key).is_err() {
-            return Err(KyError::NotFound(self.key.as_ref().to_string()));
-        }
+        let _ = pwd_db.get(&rtxn, &key)?;
 
         rtxn.commit()?;
 


### PR DESCRIPTION
This is due to #8 implementation. Encrypted keys got printed out when there are any errors. So, for now, I just removed the key from the errors, as don't know how to implement this elegantly.

But I really like to see this implemented in the futture.